### PR TITLE
Add percentile normalization to library

### DIFF
--- a/plugins/q2-perc-norm.yml
+++ b/plugins/q2-perc-norm.yml
@@ -1,0 +1,4 @@
+owner: cduvallet
+name: q2-perc-norm
+branch: master
+docs: https://github.com/cduvallet/q2-perc-norm


### PR DESCRIPTION
Hi! Let me know if this looks right. 

I tested that q2-perc-norm installs successfully in the latest amplicon QIIME 2 environment. (I did not test if the package actually works; I don't have any microbiome data to test on handy these days).

Let me know if the environment file is right - I wasn't sure if I needed to add any of my package's dependencies or if you call `pip install .` under the hood.